### PR TITLE
[Refactor] Add missing dependency for `google-api-core` in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     py_modules=["tap_ga4"],
     install_requires=[
         "google-analytics-data==0.14.0",
+        "google-api-core==2.27.0",
         "singer-python @ git+https://github.com/peliqan-io/singer-python@master",
         "requests==2.28.1",
         "backoff==2.2.1",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     py_modules=["tap_ga4"],
     install_requires=[
         "google-analytics-data==0.14.0",
-        "google-api-core==2.27.0",
+        "google-api-core<=2.27.0",
         "singer-python @ git+https://github.com/peliqan-io/singer-python@master",
         "requests==2.28.1",
         "backoff==2.2.1",


### PR DESCRIPTION
## Ticket

## Description:
* Updates the google-api-core package to use 2.27.0

## Tests
- [x] Tested in Local , its using the correct package version
- [ ] To be tested in staging